### PR TITLE
Add Canvas

### DIFF
--- a/src/main/java/com/github/Anon8281/universalScheduler/UniversalScheduler.java
+++ b/src/main/java/com/github/Anon8281/universalScheduler/UniversalScheduler.java
@@ -9,10 +9,11 @@ import org.bukkit.plugin.Plugin;
 
 public class UniversalScheduler {
     public static final boolean isFolia = JavaUtil.classExists("io.papermc.paper.threadedregions.RegionizedServer");
+    public static final boolean isCanvas = JavaUtil.classExists("io.canvasmc.canvas.server.ThreadedServer");
     public static final boolean isExpandedSchedulingAvailable = JavaUtil.classExists("io.papermc.paper.threadedregions.scheduler.ScheduledTask");
 
     public static TaskScheduler getScheduler(Plugin plugin) {
-        return isFolia ? new FoliaScheduler(plugin) : (isExpandedSchedulingAvailable ? new PaperScheduler(plugin) : new BukkitScheduler(plugin));
+        return isFolia || isCanvas ? new FoliaScheduler(plugin) : (isExpandedSchedulingAvailable ? new PaperScheduler(plugin) : new BukkitScheduler(plugin));
     }
 
 }


### PR DESCRIPTION
This adds compatibility with [CanvasMC](https://canvasmc.io/), as when the Universal Scheduler is used with regionizing enabled on Canvas, it doesn't work properly, calling region tasks off-region, crashing the server because Canvas assumes region tasks will be run on the actual region. By adding this, we ensure that the Universal Scheduler uses the proper schedulers, fixing the crashes.